### PR TITLE
Fixed typos in Global Offset Table article

### DIFF
--- a/2019-03-27-global_offset_table.md
+++ b/2019-03-27-global_offset_table.md
@@ -35,7 +35,7 @@ libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007ffff7a0d000)
 /lib64/ld-linux-x86-64.so.2 (0x00007ffff7dd7000)
 ```
 
-As you can see this are the base addresses of the libraries called. Note that
+As you can see these are the base addresses of the libraries called. Note that
 these addresses will change due to ASLR. You can see by yourself by running
 `ldd sample` multiple times. How can our simple binary know these addresses for
 the necessary libraries if they change? To find out, first lets disassemble our
@@ -197,12 +197,12 @@ this by runnning `x 0x601018` which should give us the same result.
 1. The program doesn't know at compile-time where dynamically linked libraries
    will be placed in memory, so it doesn't know exactly where functions like
 `puts` will be placed.
-2. As a result, the program will instead calls a stub function for `puts` at a
+2. As a result, the program will instead call a stub function for `puts` at a
    location is  does know, i.e., in the procedure linkage table. 
 3. The stub function (`puts@plt`) will get the runtime address of the real
    `puts` from the global offset table (a data structure updated by the linker
 at runtime).
-4. When we call a first call the library function from our C code, the linker
+4. When we first call the library function from our C code, the linker
    will update the GOT to use the correct address of the library function.
 
 ### Example
@@ -261,7 +261,7 @@ End of assembler dump.
 ```
 
 We now know the address in the GOT where the address for the `exit` C function
-is located at. Lets overwrite that using gdb. So we do `set
+is located. Lets overwrite that using gdb. So we do `set
 {int}0x804a01c=0x804853b` and we do `c` for continue. Surprise surpise, the
 program outputs
 


### PR DESCRIPTION
Fixed 4 grammatical typos in the Global Offset Table Article