### PR TITLE
Typos & Formatting

### DIFF
--- a/2019-04-19-peda_for_gdb.md
+++ b/2019-04-19-peda_for_gdb.md
@@ -14,6 +14,7 @@ that are useful for exploiting binaries (creating shellcode, ROPgadgets,
 assembling code into hexidecimal, etc.)
 
 To install PEDA:
+
 ```
 git clone https://github.com/longld/peda.git ~/peda
 echo "source ~/peda/peda.py" >> ~/.gdbinit
@@ -25,6 +26,7 @@ echo "DONE! debug your program with gdb and enjoy"
 Once PEDA is installed in gdb, start gdb normally eg. `gdb ./stack1`. When 
 you run a program, PEDA will display three sections: ***registers***, ***code***, and 
 ***stack***.
+
 ```
 gdb-peda$ b main
 Breakpoint 1 at 0x804858c: file stack1.c, line 13.
@@ -67,10 +69,12 @@ Breakpoint 1, main (argc=0x1, argv=0xffffd664) at stack1.c:13
 13	  variable = getenv("GREENIE");
 gdb-peda$ 
 ```
+
 The fist section ***registers*** displays the registers and their values.  PEDA 
 is smart and recognizes when a pointer is stored in memory and shows you the 
 value that it points to. This is useful when you need to track your input string 
 in memory.
+
 ```
 [----------------------------------registers-----------------------------------]
 EAX: 0xf7fc6dbc --> 0xffffd66c --> 0xffffd7cc ("SHELL=/bin/bash")
@@ -85,11 +89,13 @@ EIP: 0x804858c (<main+17>:	sub    esp,0xc)
 EFLAGS: 0x286 (carry PARITY adjust zero SIGN trap INTERRUPT direction overflow)
 [------------------------------------------------------------------------------]
 ```
+
 The ***code*** section displays the assembly code that it's executing.  There 
 is an arrow that points to the exact assembly instruction that is about to be 
 executed. In this example it's `sub  esp,0xc` at location `0x804858c` in 
 memory. Using the command `ni`, you can step through the instructions one by 
 one.
+
 ```
 [-------------------------------------code-------------------------------------]
    0x8048586 <main+11>:	mov    ebp,esp
@@ -102,6 +108,7 @@ one.
    0x804859c <main+33>:	mov    DWORD PTR [ebp-0xc],eax
 [------------------------------------------------------------------------------]
 ```
+
 Last, the ***stack*** section displays the contents of the stack, and shows what 
 addresses the stack is using. Here, the top of the stack is at `0xffffd560`. If 
 we look at the left side of the display, it shows the byte offset for each line. 
@@ -109,6 +116,7 @@ Since the bytes are increasing by 4 for each line, PEDA is displaying **words** 
 the stack.  This means that `0x00000000` or `0x0` is the first word, and `0xffffd604` is the 
 second. PEDA knows that the second word is a pointer so it displays what it is pointing 
 to: `0xd2ae39cc`.
+
 ```
 [------------------------------------stack-------------------------------------]
 0000| 0xffffd560 --> 0x0 
@@ -122,9 +130,11 @@ to: `0xd2ae39cc`.
 [------------------------------------------------------------------------------]
 ```
 
+
 ### PEDA's helpful commands
 
 1. `vmmap` - Get virtual mapping address ranges of section(s) in debugged process
+
 ```
 gdb-peda$ vmmap
 Start      End        Perm	Name
@@ -146,7 +156,9 @@ Start      End        Perm	Name
 0xf7ffd000 0xf7ffe000 rw-p	/lib32/ld-2.23.so
 0xfffdd000 0xffffe000 rw-p	[stack]
 ```
+
 2. `assemble` - Convert assembly code to hexidecimal instructions
+
 ```
 gdb-peda$ assemble
 Instructions will be written to stdout
@@ -163,14 +175,18 @@ Assembled instructions:
 
 hexify: "\x58\xc3"
 ```
+
 3. `find` - Find a string of characters in a page or between two addresses
+
 ```
 gdb-peda$ find “/bin/sh” libc
 Searching for '/bin/sh' in: libc ranges
 Found 1 results, display max 1 items:
 libc : 0xf7f6e02b ("/bin/sh")
 ```
+
 4. `shellcode` - Generate common shellcode
+
 ```
 gdb-peda$ shellcode generate x86/linux exec
 # x86/linux/exec: 24 bytes
@@ -179,7 +195,9 @@ shellcode = (
     "\xc9\x89\xca\x6a\x0b\x58\xcd\x80"
 )
 ```
+
 5. `ropsearch` - Search for ROP gadgets
+
 ```
 gdb-peda$ ropsearch "pop eax" libc
 Searching for ROP gadget: 'pop eax' in: libc ranges
@@ -194,7 +212,9 @@ Searching for ROP gadget: 'pop eax' in: libc ranges
 0xf7ed7d59 : (b'5804f7c3')	pop eax; add al,0xf7; ret
 ...
 ```
+
 6. `aslr` - Check ASLR setting for GDB
+
 ```
 gdb-peda$ aslr
 ASLR is OFF

--- a/writeups/2019-04-22-heap1.md
+++ b/writeups/2019-04-22-heap1.md
@@ -154,6 +154,7 @@ Chunk(addr=0x804b048, size=0x20fc0, flags=PREV_INUSE)  ←  top chunk
 The seventeenth `a` got written into the chunk for `i2`. If we wrote a few more bytes we could overwrite the address stored in `i2` to point anywhere we want. Then the second call to `strcpy` will write to that new address instead of writing into chunk 4 like it should. This gives us the power to write what ever we want, where ever we want.
 
 As an example lets use `python -c "print 'a'*20 + '\x10\x10\x10\x10'"` as our input.
+
 ```ruby
 Chunk(addr=0x804b008, size=0x10, flags=PREV_INUSE)
     [0x0804b008     01 00 00 00 18 b0 04 08 00 00 00 00 11 00 00 00    ................]
@@ -168,11 +169,13 @@ Now the second call to `strcpy` will write our b's to address `0x10101010`.
 If we know where the top of the stack is, we can now use this method to overwrite the return address so that when `main` exits, `winner` is called instead. We have used this technique several times already. Using gdb we can find out the address of `winner` is `0x804854b`. So we need to write that somewhere near the top of the stack. 
 
 So our first arugment needs to overwrite the address stored in the second struct.
+
 ```python
 python -c "print 'a'*20 + '\x??\x??\x??\x??'"
 ```
 
 And the second argument needs to be the address of `winner`.
+
 ```python
 python -c "print '\x4b\x85\x04\x08'"
 ```


### PR DESCRIPTION
Fixed formatting in heap1 writeup and peda lecture notes so that code blocks display properly on the website.